### PR TITLE
Add enablePlugins recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.1
 
 * Exporter application will now be deleted after generation (#106)
+* It is now recommended adding `.enablePlugins(ScalaTsiPlugin)` to your sbt project. This will become mandatory in a future release (#110)
 
 ## 0.4.0 - 2020-09-11
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ And configure the plugin in your project:
 ```scala
 // Replace with your project definition
 lazy val root = (project in file("."))
+    .enablePlugins(ScalaTsiPlugin)
     .settings(
       // The classes that you want to generate typescript interfaces for
       typescriptExports := Seq("MyClass"),

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,6 +1,7 @@
 import sbt.Keys._
 
 lazy val root = (project in file("."))
+  .enablePlugins(ScalaTsiPlugin)
   .settings(
     Seq(
       scalaVersion := "2.13.3",

--- a/plugin/src/main/scala/com/scalatsi/plugin/ScalaTsiPlugin.scala
+++ b/plugin/src/main/scala/com/scalatsi/plugin/ScalaTsiPlugin.scala
@@ -29,6 +29,8 @@ object ScalaTsiPlugin extends AutoPlugin {
 
   import autoImport._
 
+  // TODO: On breaking release, change allRequirements into noTrigger to not automatically enable the plugin
+  //override def trigger = noTrigger
   override def trigger = allRequirements
 
   private val scala_ts_compiler_version = BuildInfo.version

--- a/plugin/src/sbt-test/ScalaTsiPlugin/clean-after-run/build.sbt
+++ b/plugin/src/sbt-test/ScalaTsiPlugin/clean-after-run/build.sbt
@@ -1,6 +1,7 @@
 import sbt.Keys._
 
 lazy val root = (project in file("."))
+  .enablePlugins(ScalaTsiPlugin)
   .settings(
     Seq(
       scalaVersion := "2.13.3",


### PR DESCRIPTION
This plugin adds scala-tsi as a library dependency for every project in a build.sbt

This is fine for applications or single-project builds, but is problematic for multi-project builds where not every project should have this dependency.