### PR TITLE
Change SBT plugin publish style from Ivy to Maven

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,10 @@ jobs:
             set -x
             if [ -z "$CIRCLE_PR_USERNAME" ]; then
               gpg --batch --yes --import .circleci/circleci.key.asc
-              sbt -batch ++"<< parameters.scala-version >>.x" publishLocalSigned sbt-scala-tsi/publishLocalSigned
+              sbt -batch ++"<< parameters.scala-version >>.x" publishM2 publishLocalSigned sbt-scala-tsi/publishLocalSigned
             else
               # On forked PR, do an unsigned publish
-              sbt -batch ++"<< parameters.scala-version >>.x" publishLocal sbt-scala-tsi/publishLocal
+              sbt -batch ++"<< parameters.scala-version >>.x" publishM2 publishLocal sbt-scala-tsi/publishLocal
             fi
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,16 @@ jobs:
             set -x
             if [ -z "$CIRCLE_PR_USERNAME" ]; then
               gpg --batch --yes --import .circleci/circleci.key.asc
-              sbt -batch ++"<< parameters.scala-version >>.x" publishM2 publishLocalSigned sbt-scala-tsi/publishLocalSigned
+              sbt -batch ++"<< parameters.scala-version >>.x" \
+                publishLocalSigned \
+                sbt-scala-tsi/publishLocalSigned \
+                sbt-scala-tsi/publishM2
             else
               # On forked PR, do an unsigned publish
-              sbt -batch ++"<< parameters.scala-version >>.x" publishM2 publishLocal sbt-scala-tsi/publishLocal
+              sbt -batch ++"<< parameters.scala-version >>.x" \
+                publishLocal \
+                sbt-scala-tsi/publishLocal \
+                sbt-scala-tsi/publishM2
             fi
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,12 +60,14 @@ jobs:
               gpg --batch --yes --import .circleci/circleci.key.asc
               sbt -batch ++"<< parameters.scala-version >>.x" \
                 publishLocalSigned \
+                publishM2 \
                 sbt-scala-tsi/publishLocalSigned \
                 sbt-scala-tsi/publishM2
             else
               # On forked PR, do an unsigned publish
               sbt -batch ++"<< parameters.scala-version >>.x" \
                 publishLocal \
+                publishM2 \
                 sbt-scala-tsi/publishLocal \
                 sbt-scala-tsi/publishM2
             fi

--- a/build.sbt
+++ b/build.sbt
@@ -45,9 +45,6 @@ lazy val publishSettings = Seq(
         pgpSecretRing := file(".circleci/circleci.key.asc"),
         pgpPublicRing := file(".circleci/circleci.pub.asc"),
         pgpPassphrase := sys.env.get("GPG_passphrase").map(_.toCharArray),
-        // For some reason without these the dependencies can't be found on CI when testing locally
-        (publishLocal / publishMavenStyle).withRank(KeyRanks.Invisible)       := false,
-        (publishLocalSigned / publishMavenStyle).withRank(KeyRanks.Invisible) := false
       )
     })
     .getOrElse(Seq())

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -25,7 +25,7 @@ lazy val root = (project in file("."))
       typescriptGenerationImports        := Seq("models._", "ReadmeTSTypes._", "models.enumeration._"),
       typescriptOutputFile               := baseDirectory.value / "model.ts",
       typescriptTaggedUnionDiscriminator := Some("kind"),
-      scalafmtConfig                     := file("../.scalafmt.conf")
+      scalafmtConfig                     := file("../.scalafmt.conf"),
     )
   )
 

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -26,7 +26,8 @@ lazy val root = (project in file("."))
       typescriptOutputFile               := baseDirectory.value / "model.ts",
       typescriptTaggedUnionDiscriminator := Some("kind"),
       scalafmtConfig                     := file("../.scalafmt.conf"),
-    )
+      resolvers += Resolver.mavenLocal
+    ),
   )
 
 lazy val compilerOptions = scalacOptions := Seq(

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -1,3 +1,4 @@
+resolvers += Resolver.mavenLocal
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 
 lazy val logger = ConsoleLogger()


### PR DESCRIPTION
#272 added the following to build.sbt:

```sbt
// For some reason without these the dependencies can't be found on CI when testing locally
(publishLocal / publishMavenStyle).withRank(KeyRanks.Invisible)       := false,
(publishLocalSigned / publishMavenStyle).withRank(KeyRanks.Invisible) := false
```

This was intended only to affect local publishes, but seems to have affected maven central publishes too: #282 