### PR TITLE
split toOutput method to avoid too large methods (#304)

### DIFF
--- a/plugin/src/main/twirl/ExportTypescriptTemplate.scala.txt
+++ b/plugin/src/main/twirl/ExportTypescriptTemplate.scala.txt
@@ -13,10 +13,13 @@ import java.io.File
 import @imp }
 
 object ExportTypescript {
+  @for(userClass <- classes) {
+  def  `tstype_@userClass` = TSType.getOrGenerate[@userClass].get }
+
   // If you get a generator or implicit not found error here, make sure you have defined a TSType[T] implicit and imported it
   val toOutput: Map[String, TypescriptType] = Map[String, TypescriptType](
     @for(userClass <- classes) {
-      """@userClass""" -> TSType.getOrGenerate[@userClass].get, }
+      """@userClass""" -> `tstype_@userClass`, }
   )
 
   val options = output.OutputOptions(


### PR DESCRIPTION
We ran into the same issues as https://github.com/scala-tsi/scala-tsi/issues/304. in a Scala 2 project.

I've implemented [your suggestion](https://github.com/scala-tsi/scala-tsi/issues/304#issuecomment-1661724080)of splitting the code generation into multiple methods and that solved the issue for us.

