### PR TITLE
Revert "Update scala3-library to 3.4.1"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import com.jsuereth.sbtpgp.PgpKeys.publishLocalSigned
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-val scala3   = "3.4.1"
+val scala3   = "3.3.3"
 val scala213 = "2.13.12"
 val scala212 = "2.12.17" // for sbt
 

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,6 +1,6 @@
 import sbt.Keys._
 
-val scala3   = "3.4.1"
+val scala3   = "3.3.3"
 val scala213 = "2.13.12"
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
Reverts scala-tsi/scala-tsi#334

Breaks the build due this incorrectly configured branch protection settings